### PR TITLE
fix: align display panel driver setup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ esp-hal-embassy = { version = "0.9.0", features = ["esp32s3"] }
 esp-println = { version = "0.15.0", features = ["esp32s3", "defmt-espflash"] }
 
 # Display driver and drawing
-# Use local submodule for GC9D01 with panel_160x50 tuning; async is enabled by default in the crate branch
+# Use local submodule for GC9D01 with panel_160x50 tuning.
 gc9d01 = { path = "gc9d01", default-features = false, features = ["defmt", "panel_160x50", "async"] }
 embedded-graphics = { version = "0.8", default-features = false }
 

--- a/docs/esp32-s3fh4r2_gpio_assignment_guide.md
+++ b/docs/esp32-s3fh4r2_gpio_assignment_guide.md
@@ -152,7 +152,7 @@
 | **GPIO12** | 17 | SPI_SCLK | SPI时钟 | ⚡ IOMUX直连，最高80MHz |
 | **GPIO13** | 18 | SPI_CS | 片选信号 | ⚡ IOMUX直连，最低延迟 |
 | **GPIO14** | 19 | SPI_RES | 复位信号 | SPI屏幕复位控制 |
-| **GPIO15** | 21 | SPI_BLK | PWM背光控制 | SPI屏幕背光调节 |
+| **GPIO15** | 21 | SPI_BLK | 背光控制 | 低有效；驱动前面板 P 沟道背光门极 |
 | **GPIO16** | 22 | I2C_INT | I2C设备中断引脚 | 中断处理 |
 | **GPIO17** | 23 | PSTOP_CTL1 | SC8815 通道1 启停控制 | 高电平启用（板上反相，PSTOP 低有效） |
 | **GPIO18** | 24 | PSTOP_CTL2 | SC8815 通道2 启停控制 | 高电平启用（板上反相，PSTOP 低有效） |

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -66,5 +66,6 @@
 |------:|------------|-----------|------------------------------------------|------------|--------|
 | k3p8m | 示例：新增工作项规格 | 待设计       | `k3p8m-example-spec/SPEC.md`             | YYYY-MM-DD | -      |
 | 5f74j | 固件健壮化与开机自检 | 已完成 | `5f74j-firmware-boot-self-check/SPEC.md` | 2026-03-17 | 当前板型为直连 I2C；保留 mux 槽位以兼容后续 PCA9545A |
+| j6nvw | 硬件 V3 引脚与显示链路对齐 | 部分完成（2/3） | `j6nvw-hardware-v3-pin-assignment/SPEC.md` | 2026-04-27 | legacy `docs/plan/j6nvw-hw-v3-pin-assignment/**` 删除待确认 |
 | e5nyr | 发布失败 Telegram 告警接入 | 已完成 | `e5nyr-release-failure-telegram-alerts/SPEC.md` | 2026-04-12 | PR #12 |
 <!-- markdownlint-enable MD060 -->

--- a/docs/specs/j6nvw-hardware-v3-pin-assignment/HISTORY.md
+++ b/docs/specs/j6nvw-hardware-v3-pin-assignment/HISTORY.md
@@ -1,0 +1,14 @@
+# 硬件 V3 引脚与显示链路历史
+
+## 关键演进
+
+- V3 网表确认显示屏 SPI 与 `DC/CS/RST/BLK` 由 MCU GPIO 直接控制，前面板 `TCA6408A` 不参与显示控制。
+- 实物验证发现背光需要低电平使能；网表显示 `BLK` 驱动 P 沟道门极，与低有效固件行为一致。
+- 屏幕实装方向需要 180 度旋转；driver 侧 `LandscapeSwapped` 映射修复后，主项目切换到该方向。
+
+## Legacy Source
+
+- `docs/plan/j6nvw-hw-v3-pin-assignment/PLAN.md`
+- `docs/plan/j6nvw-hw-v3-pin-assignment/hardware_v3_pin_assignment.md`
+
+legacy 源文档暂时保留；删除需主人确认。

--- a/docs/specs/j6nvw-hardware-v3-pin-assignment/IMPLEMENTATION.md
+++ b/docs/specs/j6nvw-hardware-v3-pin-assignment/IMPLEMENTATION.md
@@ -1,0 +1,26 @@
+# 硬件 V3 引脚与显示链路实现状态
+
+## 当前状态
+
+- 主项目显示路径使用 MCU 直接控制 `DC/CS/RST/BLK`。
+- `LCD_BLK` 按低有效处理，输出低电平打开背光。
+- `DisplayConfig.orientation` 使用 `Orientation::LandscapeSwapped`。
+- `gc9d01` submodule 指向包含 `LandscapeSwapped` 坐标修复的 driver `main`。
+
+## Coverage
+
+- 固件：显示初始化、背光极性、屏幕方向。
+- 文档：GPIO assignment 中 `SPI_BLK` 极性。
+- Driver：通过 submodule 指针引用已合并的 `gc9d01-rs` 修复。
+
+## Remaining Gaps
+
+- legacy `docs/plan/j6nvw-hw-v3-pin-assignment/**` 尚未删除，等待主人确认。
+- V3 pinmap 中与显示无关的历史条目仍需后续独立清理。
+
+## Related Changes
+
+- `src/main.rs`
+- `Cargo.toml`
+- `docs/esp32-s3fh4r2_gpio_assignment_guide.md`
+- `gc9d01`

--- a/docs/specs/j6nvw-hardware-v3-pin-assignment/SPEC.md
+++ b/docs/specs/j6nvw-hardware-v3-pin-assignment/SPEC.md
@@ -1,0 +1,121 @@
+# 硬件 V3 引脚与显示链路对齐（#j6nvw）
+
+## 状态
+
+- Status: 部分完成（2/3）
+- Created: 2026-02-06
+- Last: 2026-04-27
+
+## 背景 / 问题陈述
+
+- V3 硬件把显示屏 SPI 与控制脚接到 MCU GPIO，前面板 `TCA6408A` 只承载五向按键输入。
+- `BLK` 网络连接到前面板 P 沟道背光门极，固件若按高有效驱动会导致背光关闭。
+- 160x50 屏幕实装方向需要使用 driver 的 `LandscapeSwapped` 坐标变换；旧 driver 中该方向与 `Landscape` 映射相同，主项目必须引用已修复版本。
+
+## 目标 / 非目标
+
+### Goals
+
+- 固件显示 GPIO、背光极性和屏幕方向与 V3 网表及实物行为一致。
+- 主项目引用已合并的 `gc9d01-rs` driver 修复版本。
+- 保留 V3 pin assignment 的 canonical spec 入口，后续实现与文档以本目录为准。
+
+### Non-goals
+
+- 不改变前面板连接器定义。
+- 不把显示 CS/RES 迁回 `TCA6408A` 控制。
+- 不在本规格内重做 dashboard 视觉设计。
+
+## 范围
+
+### In scope
+
+- `src/main.rs` 的显示初始化配置。
+- `gc9d01` submodule 指针。
+- V3 GPIO 文档中 `SPI_BLK` 极性描述。
+
+### Out of scope
+
+- USB 输出模块电源策略重构。
+- CH335F sideband 行为。
+- 前面板按键任务功能扩展。
+
+## 需求
+
+### MUST
+
+- `LCD_DC/LCD_MOSI/LCD_SCLK/LCD_CS/LCD_RST/LCD_BLK` 使用 V3 网表定义的 MCU GPIO。
+- `LCD_BLK` 必须按低有效背光使能处理。
+- display config 必须使用 `Orientation::LandscapeSwapped`，并依赖包含该映射修复的 `gc9d01-rs` 版本。
+- 前面板 `TCA6408A@0x21` 离线不得阻断 dashboard。
+
+### SHOULD
+
+- 固件日志应明确当前显示控制路径为 MCU CS/RST。
+- 项目文档应标出 `SPI_BLK` 的低有效语义。
+
+## 功能与行为规格
+
+- 启动时固件先初始化 SPI2 与显示 GPIO，然后初始化 GC9D01 160x50 panel。
+- `BLK` 输出低电平后背光打开。
+- framebuffer 以 160x50 逻辑尺寸渲染，driver 负责 `LandscapeSwapped` 到物理坐标的转换。
+- `TCA6408A@0x21` 只影响前面板按键 gate，不影响 LCD dashboard 刷新。
+
+## 验收标准
+
+- Given V3 前面板与显示屏焊接正确，When 固件启动，Then 背光点亮且 LCD 初始化日志显示 `mcu cs/rst, landscape-swapped`。
+- Given dashboard 正常刷新，When 观察屏幕方向，Then 画面相对旧 `Landscape` 配置旋转 180 度。
+- Given 前面板 `TCA6408A@0x21` 在线，When 固件完成自检，Then 日志报告前面板 online 并继续 dashboard。
+- Given 前面板 `TCA6408A@0x21` 离线，When 固件完成自检，Then dashboard 仍可运行。
+
+## 实现前置条件
+
+- V3 网表已导入仓库：`docs/hardware/mainboard_netlist.enet.enet` 与 `docs/hardware/front_panel_netlist.enet.enet`。
+- `gc9d01-rs` 的 `LandscapeSwapped` 坐标映射修复已合并到 driver `main`。
+
+## 非功能性验收 / 质量门槛
+
+### Testing
+
+- `cargo +esp check`
+- `cargo +esp build --release`
+
+### UI / Visual Evidence
+
+- 使用 dashboard preview 生成 160x50 正常态与混合状态预览。
+- PR 阶段展示至少一张稳定快照图。
+
+## Visual Evidence
+
+正常态预览：
+
+![Dashboard 160x50 normal](../../assets/dashboard_wireframe_160x50_color_bold.svg)
+
+混合状态预览：
+
+![Dashboard 160x50 states](../../assets/dashboard_wireframe_160x50_states_color_bold.svg)
+
+## 文档更新
+
+- `docs/esp32-s3fh4r2_gpio_assignment_guide.md`
+- `docs/specs/j6nvw-hardware-v3-pin-assignment/IMPLEMENTATION.md`
+- `docs/specs/j6nvw-hardware-v3-pin-assignment/HISTORY.md`
+
+## 实现里程碑
+
+- [x] M1: 建立 V3 pin assignment canonical spec，并保留 legacy plan 删除确认边界
+- [x] M2: 显示背光、方向和 driver submodule 指针对齐
+- [ ] M3: 完成其余 V3 pinmap 历史文档清理与 legacy `docs/plan/**` 删除
+
+## 风险 / 开放问题 / 假设
+
+- 风险：若后续硬件修改 `BLK` 驱动拓扑，需要同步调整固件极性和文档。
+- 开放问题：legacy `docs/plan/j6nvw-hw-v3-pin-assignment/**` 删除需要主人确认。
+- 假设：V3 显示连接器定义正确，固件只需对齐 GPIO、极性、方向和 driver 版本。
+
+## 参考
+
+- `docs/hardware/mainboard_netlist.enet.enet`
+- `docs/hardware/front_panel_netlist.enet.enet`
+- `docs/plan/j6nvw-hw-v3-pin-assignment/PLAN.md`
+- `docs/plan/j6nvw-hw-v3-pin-assignment/hardware_v3_pin_assignment.md`

--- a/src/main.rs
+++ b/src/main.rs
@@ -144,10 +144,9 @@ const MODULE_TMP112_ADDRS: [u8; 4] = [0x48, 0x49, 0x4A, 0x4B];
 const MODULE_SENSOR_RETRY_MS: u64 = 50;
 const MODULE_SENSOR_RETRIES: u8 = 6;
 
-// ===== Display pin mapping (assumed; please confirm) =====
-// SPI2 SCLK/MOSI to panel; MISO unused.
-// DC uses MCU GPIO (data/command). Backlight not managed here.
-// 回退实现：MCU 直接控制 CS/RES，与示例一致
+// ===== Display pin mapping (V3 netlist) =====
+// SPI2 SCLK/MOSI to panel; MISO unused. MCU directly drives DC/CS/RES/BLK.
+// BLK drives a panel-side P-channel gate and is therefore active-low.
 const PIN_LCD_SCLK: u8 = 12;
 const PIN_LCD_MOSI: u8 = 11;
 const PIN_LCD_DC: u8 = 10;
@@ -207,7 +206,7 @@ async fn sample_module_ina226(ch: u8) -> Option<(u32, u32)> {
 
 // NOTE: no arbitrary address enumeration; only probe known devices.
 
-// 按项目要求：不在固件中操作 TCA6408A（不扫描/不复位/不拉 CS），RES/CS 由外部电路或其它控制实体负责。
+// The front-panel TCA6408A is used for key input only; display CS/RES are MCU GPIOs.
 
 // Embassy timer adapter for the display driver
 struct DisplayTimer;
@@ -750,10 +749,10 @@ async fn main(spawner: Spawner) {
         .with_scl(p.GPIO9)
         .into_async();
     let bus = I2C_BUS.init(Mutex::new(i2c_hw));
-    // MCU 直接控制 CS/RES（回退实现）
+    // MCU 直接控制 CS/RES（V3 网表）
     info!("lcd.ctrl: cs,res via MCU GPIO");
 
-    // Setup SPI2 and display. CS/RES 由 TCA6408A 控制（本固件不介入）。
+    // Setup SPI2 and display. CS/RES/BLK are direct MCU GPIOs.
     let spi_bus = Spi::new(
         p.SPI2,
         SpiConfig::default()
@@ -775,12 +774,12 @@ async fn main(spawner: Spawner) {
         10 => Output::new(p.GPIO10, Level::Low, esp_hal::gpio::OutputConfig::default()),
         _ => Output::new(p.GPIO10, Level::Low, esp_hal::gpio::OutputConfig::default()),
     };
-    // Backlight on (high)
+    // Backlight enable is active-low through the panel-side P-MOS gate.
     let mut blk = match PIN_LCD_BLK_GPIO {
         15 => Output::new(p.GPIO15, Level::Low, esp_hal::gpio::OutputConfig::default()),
         _ => Output::new(p.GPIO15, Level::Low, esp_hal::gpio::OutputConfig::default()),
     };
-    blk.set_high();
+    blk.set_low();
 
     const LOGICAL_W: usize = 160;
     const LOGICAL_H: usize = 50;
@@ -807,7 +806,7 @@ async fn main(spawner: Spawner) {
     let cfg = DisplayConfig {
         width: LOGICAL_W as u16,
         height: LOGICAL_H as u16,
-        orientation: Orientation::Landscape,
+        orientation: Orientation::LandscapeSwapped,
         rgb: false,
         inverted: false,
         dx: 15,
@@ -826,7 +825,7 @@ async fn main(spawner: Spawner) {
         ),
     };
     let mut disp: GC9D01<_, _, _, DisplayTimer> = GC9D01::new(cfg, spi_dev, dc, rst, fb);
-    info!("lcd.init: start panel_160x50 mode (fallback MCU CS/RST)");
+    info!("lcd.init: start panel_160x50 mode (mcu cs/rst, landscape-swapped)");
     if let Err(_e) = disp.init().await {
         warn!("lcd.init: failed (fallback)");
     } else {


### PR DESCRIPTION
## Summary
- Align the main firmware display setup with the V3 panel wiring: MCU-driven CS/RST/BLK, active-low backlight, and `LandscapeSwapped` orientation.
- Advance the `gc9d01` submodule to the merged driver fix for `LandscapeSwapped` coordinate mapping.
- Add the canonical V3 display/pin assignment spec entry and update the GPIO guide for `SPI_BLK` low-active behavior.

## Validation
- `source ~/export-esp.sh && cargo +esp fmt --all -- --check`
- `source ~/export-esp.sh && cargo +esp check`
- `source ~/export-esp.sh && cargo +esp build --release`
- `cargo +stable run --manifest-path tools/dashboard_preview/Cargo.toml --config 'build.target="aarch64-apple-darwin"' --config 'unstable.build-std=[]'`
- `bunx markdownlint-cli2 docs/specs/README.md docs/specs/j6nvw-hardware-v3-pin-assignment/*.md docs/esp32-s3fh4r2_gpio_assignment_guide.md`
- `git diff --check`

## Visual Evidence
- Spec references the stable 160x50 dashboard previews in `docs/specs/j6nvw-hardware-v3-pin-assignment/SPEC.md`.
- Chat snapshots were generated from `docs/assets/dashboard_wireframe_160x50_color_bold.svg` and `docs/assets/dashboard_wireframe_160x50_states_color_bold.svg`.

## References
- Spec: `docs/specs/j6nvw-hardware-v3-pin-assignment/SPEC.md`
- Spec Disposition: update
- Spec Sync: done
- Spec Drift: none
- Solutions: -
- Solutions Sync: n/a(no related solution)
- Project Docs: `docs/esp32-s3fh4r2_gpio_assignment_guide.md`
- Project Docs Sync: done

## Notes
- Legacy source retained pending delete approval: `docs/plan/j6nvw-hw-v3-pin-assignment/**`.
- Full-repo markdownlint still has pre-existing failures in unrelated docs; the changed docs subset passes.